### PR TITLE
fix: navbar on mobile

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -1,6 +1,5 @@
 ---
 import MobileNav from "../layout/MobileNav.astro";
-import ThemeIcon from "../generic/ThemeIcon.astro";
 ---
 
 <header>
@@ -132,14 +131,19 @@ import ThemeIcon from "../generic/ThemeIcon.astro";
       }
     }
 
+    @media only screen and (width < 640px) and (-webkit-min-device-pixel-ratio: 1) {
+      .linkText {
+        display: none;
+      }
+
+      #btn {
+        display: none;
+      }
+    }
+
     @media only screen and (min-width: 640px) and (-webkit-min-device-pixel-ratio: 1) {
       .navigation {
         justify-content: space-between;
-        
-      }
-
-      .navigation_mobile {
-        display: none;
       }
     }
 

--- a/src/components/layout/MobileNav.astro
+++ b/src/components/layout/MobileNav.astro
@@ -10,16 +10,25 @@
   });
 </script>
 
-<div id="myNav" class="overlay">
-  <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
+<!-- close animation needed to fix -->
+<div id="myNav" class="overlay dark:bg-[#090909] bg-white">
+  <div>
+    <button id="btn-mobile" class="absolute top-12 left-4 h-12 w-12 rounded-lg p-2 hover:bg-gray-100 dark:hover:bg-gray-700">
+      <svg id="dark-icon" class="fill-slate-700 block dark:hidden dark" fill="currentColor" viewBox="0 0 20 20">
+        <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
+      </svg>
+      <svg id="light-icon" class="fill-yellow-500 hidden dark:block light" fill="currentColor" viewBox="0 0 20 20">
+        <path d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" fill-rule="evenodd" clip-rule="evenodd"></path>
+      </svg>
+    </button>
+    <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a> <!-- needed to fix this css -->
+  </div>
 
   <div class="overlay-content">
-    <a class="linkText" href="/blog">All Research</a>
-      <ul class="navigation_social">
-        <li>
-          <a href="https://discord.com/invite/n2MCt83TBZ" class="button-primary"
-            >Join Community</a
-          >
+    <a class="linkText" href="/blog">All Research</a> <!-- needed to fix this css -->
+    <ul class="navigation_social">
+      <li>
+          <a class="button-primary" href="https://discord.gg/2077collective">Join Community</a> <!-- needed to fix this css -->
         </li>
       </ul>
   </div>
@@ -35,8 +44,6 @@
     z-index: 1;
     left: 0;
     top: 0;
-    background-color: #090909;
-    background-color: #090909;
     overflow-x: hidden;
     transition: 0.5s;
   }
@@ -91,8 +98,13 @@
     }
   }
 
-  @media only screen and (min-width: 1024px) and (-webkit-min-device-pixel-ratio: 1) {
+  @media only screen and (width >= 640px) and (-webkit-min-device-pixel-ratio: 1) {
+      .myNav {
+        display: none;
+      }
+
       .menu {
-      display: none;}
+        display: none;
+      }
     }
 </style>

--- a/src/layouts/Default.astro
+++ b/src/layouts/Default.astro
@@ -33,6 +33,7 @@ const _ogImage = new URL(
     <script is:inline>
       const theme = () => {
         let btn = document.querySelector("#btn");
+        let btn_mobile = document.querySelector("#btn-mobile");
         const toggleDarkMode = () => {
           document.documentElement.classList.toggle("dark");
           const isDarkMode =
@@ -40,6 +41,7 @@ const _ogImage = new URL(
           localStorage.setItem("theme", isDarkMode ? "dark" : "light");
         };
         btn.addEventListener("click", toggleDarkMode);
+        btn_mobile.addEventListener("click", toggleDarkMode);
       };
 
       theme();


### PR DESCRIPTION
## Changes

- Hide **All Research** button and theme button (display < 640px)
- Hide **MENU** button (display >= 640px)
- Add theme button on mobile menu with class `btn-mobile` (has been functionally)

Display <640px before & after:

![image](https://github.com/user-attachments/assets/5298cc47-1c6e-44bf-b7ab-fab763274e77)

![image](https://github.com/user-attachments/assets/f73e8080-847d-468b-9e9c-9c245e2e5b70)

Display >=640px before & after:

![image](https://github.com/user-attachments/assets/9823788c-5fab-414b-8e72-d9167eeb047a)

![image](https://github.com/user-attachments/assets/e8eea9a6-55ac-4324-9b94-58ccee0583fa)

Mobile menu before & after:

![image](https://github.com/user-attachments/assets/3ec3a0a6-9fc8-45aa-a6df-42a018494be0)

![image](https://github.com/user-attachments/assets/c4deb702-f9de-4ce9-a595-3b7bf4009e67)

## Docs

-