### PR TITLE
chore: cached fetch

### DIFF
--- a/src/components/ArticleBody.svelte
+++ b/src/components/ArticleBody.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <div
-    class="text-red
+    class="
     max-w-screen-lg m-auto flex flex-col gap-y-4 mb-32 dark:text-white
     [&>p>a]:text-green-900 [&>p>a]:font-semibold
     [&>h1]:text-3xl [&>h2]:text-2xl [&>h3]:text-xl [&>h4]:text-lg [&>h1]:font-semibold

--- a/src/components/ArticleBody.svelte
+++ b/src/components/ArticleBody.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-    import { onMount } from 'svelte'
-
     export let content: string
 </script>
 

--- a/src/pages/[categories]/[category].astro
+++ b/src/pages/[categories]/[category].astro
@@ -28,7 +28,6 @@ try {
         throw new Error(`HTTP error! status: ${response.status}`)
     }
     const data = await response.json()
-    console.log(data)
     articles = data.data
 } catch (error) {
     console.error('Error fetching articles:', error)

--- a/src/pages/[id].astro
+++ b/src/pages/[id].astro
@@ -6,6 +6,7 @@ import {
     FacebookShareButton,
     TwitterShareButton,
 } from 'astro-social-share'
+import { cachedFetch } from '../utils/cached-fetch'
 
 interface Category {
     name: string
@@ -37,11 +38,11 @@ const id = Astro.params.id
 let article: Article | null = null
 
 try {
-    const response = await fetch(`https://cms.2077.xyz/api/articles/${id}`)
+    const response = await cachedFetch(`https://cms.2077.xyz/api/articles/${id}`)
     if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`)
     }
-    const data = await response.json()
+    const data = await response.clone().json()
 
     if (data && data.success && data.data) {
         article = data as Article

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,12 +3,13 @@ import Layout from '../layouts/Layout.astro'
 import { type Article } from '../types/article'
 import SideMenu from '../components/SideMenu.svelte'
 import ArticleList from '../components/ArticleList.svelte'
+import { cachedFetch } from '../utils/cached-fetch'
 
 let articles: Article[] = []
 
 try {
-    const response = await fetch('https://cms.2077.xyz/api/articles')
-    articles = await response.json()
+    const response = await cachedFetch('https://cms.2077.xyz/api/articles')
+    articles = await response.clone().json()
 } catch (error) {
     console.error(error)
 }

--- a/src/utils/cached-fetch.ts
+++ b/src/utils/cached-fetch.ts
@@ -1,0 +1,12 @@
+const cache = new Map<string, Promise<Response>>()
+
+export async function cachedFetch(url: string): Promise<Response> {
+    if (cache.has(url)) {
+        return cache.get(url)!
+    }
+
+    const promise = fetch(url)
+    cache.set(url, promise)
+
+    return promise
+}


### PR DESCRIPTION
Implements `cachedFetch`,  which is basically a fetch with a cache layer on top. The function stores the `Promise` returned from `fetch` in memory, and if the same url is requested again, we return the cached promise.

Notice that we must use `clone` before consuming the response body. If we read from it more than once JS throws an error saying body was already read