### PR TITLE
refactor: fetch article list on client

### DIFF
--- a/src/components/ArticleList.svelte
+++ b/src/components/ArticleList.svelte
@@ -1,57 +1,90 @@
 <script lang="ts">
     import { type Article } from '../types/article'
     import { category } from '../stores/filters.store'
+    import ArticleListSkeleton from './ArticleListSkeleton.svelte'
+    import { cachedFetch } from '../utils/cached-fetch'
+    import { onMount } from 'svelte'
+    import { articles, setArticles } from '../stores/articles.store'
 
-    export let articles: Article[]
     let filteredArticles: Article[]
+    let loading = true
 
     $: {
         if ($category === undefined) {
-            filteredArticles = articles
+            filteredArticles = [...$articles]
         } else {
-            filteredArticles = articles.filter((article) =>
+            filteredArticles = $articles.filter((article) =>
                 article.categories.some(
                     (articleCategory) => $category === articleCategory.name,
                 ),
             )
         }
     }
+
+    async function fetchArticles() {
+        try {
+            loading = true
+
+            if ($articles.length > 0) {
+                return
+            }
+
+            const response = await cachedFetch(
+                'https://cms.2077.xyz/api/articles',
+            )
+
+            setArticles(await response.clone().json())
+        } catch (error) {
+            console.error(error)
+        } finally {
+            loading = false
+        }
+    }
+
+    onMount(fetchArticles)
 </script>
 
 <ul
-    class="mb-32 grid sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-12 gap-y-10 xl:w-5/6"
+    class="mb-32 grid sm:grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-12 gap-y-10"
 >
-    {#each filteredArticles as article (article.id)}
-        <li class="flex flex-col gap-y-1 group cursor-pointer">
-            <a class="bg-transparent" href={`/${article.slug}`}>
-                <img
-                    src={article.thumb}
-                    alt=""
-                    width="720"
-                    height="480"
-                    class="group-hover:opacity-80 dark:group-hover:opacity-50 transition-opacity"
-                />
-                <ul class="flex py-2">
-                    {#each article.categories as category}
-                        <li class="">
-                            <a
-                                href={`/categories/${category.name}`}
-                                class="mr-2 flex items-center gap-0.5 text-[12px] bg-[#1B1B1B] text-[#C6FF50] max-w-fit-content px-2 py-1 rounded-md"
-                            >
-                                {category.name}
-                            </a>
-                        </li>
-                    {/each}
-                </ul>
-                <h2
-                    class="mb-2 text-md font-semibold underline decoration-white dark:decoration-black group-hover:decoration-black dark:group-hover:decoration-white transition-colors leading-5"
-                >
-                    {article.title}
-                </h2>
-                <p class="text-sm text-gray-900 font-bold leading-17">
-                    {article.summary}
-                </p>
-            </a>
-        </li>
-    {/each}
+    {#if loading}
+        {#each Array(6) as _}
+            <ArticleListSkeleton />
+        {/each}
+    {/if}
+    {#if !loading}
+        {#each filteredArticles as article (article.id)}
+            <li class="flex flex-col gap-y-1 group cursor-pointer">
+                <a class="bg-transparent" href={`/${article.slug}`}>
+                    <img
+                        src={article.thumb}
+                        alt=""
+                        width="720"
+                        height="480"
+                        class="group-hover:opacity-80 dark:group-hover:opacity-50 transition-opacity"
+                    />
+                    <ul class="flex py-2">
+                        {#each article.categories as category}
+                            <li class="">
+                                <a
+                                    href={`/categories/${category.name}`}
+                                    class="mr-2 flex items-center gap-0.5 text-[12px] bg-[#1B1B1B] text-[#C6FF50] max-w-fit-content px-2 py-1 rounded-md"
+                                >
+                                    {category.name}
+                                </a>
+                            </li>
+                        {/each}
+                    </ul>
+                    <h2
+                        class="mb-2 text-md font-semibold underline decoration-white dark:decoration-black group-hover:decoration-black dark:group-hover:decoration-white transition-colors leading-5"
+                    >
+                        {article.title}
+                    </h2>
+                    <p class="text-sm text-gray-900 font-bold leading-17">
+                        {article.summary}
+                    </p>
+                </a>
+            </li>
+        {/each}
+    {/if}
 </ul>

--- a/src/components/ArticleListSkeleton.svelte
+++ b/src/components/ArticleListSkeleton.svelte
@@ -1,7 +1,7 @@
 <li class="flex flex-col gap-y-1 group cursor-pointer">
     <div class="bg-gray-100 dark:bg-gray-900 animate-pulse rounded-md">
         <img
-            src="#"
+            src="/images/block-stm-sealevel/1.png"
             alt=""
             width="720"
             height="400"

--- a/src/components/ArticleListSkeleton.svelte
+++ b/src/components/ArticleListSkeleton.svelte
@@ -1,0 +1,43 @@
+<li class="flex flex-col gap-y-1 group cursor-pointer">
+    <div class="bg-gray-100 dark:bg-gray-900 animate-pulse rounded-md">
+        <img
+            src="#"
+            alt=""
+            width="720"
+            height="400"
+            class="group-hover:opacity-80 dark:group-hover:opacity-50 transition-opacity invisible h-auto w-auto"
+        />
+    </div>
+
+    <ul class="flex py-2 w-full gap-2">
+        <li class="w-2/3">
+            <div
+                class="mr-2 flex items-center gap-0.5 text-[12px] bg-gray-100 dark:bg-gray-900 animate-pulse max-w-fit-content rounded-md p-3 w-full"
+            />
+        </li>
+
+        <li class="w-full">
+            <div
+                class="mr-2 flex items-center gap-0.5 text-[12px] bg-gray-100 dark:bg-gray-900 max-w-fit-content rounded-md animate-pulse p-3 w-2/3"
+            />
+        </li>
+    </ul>
+
+    <div class="flex flex-col gap-1 mb-2">
+        <div
+            class="text-md font-semibold leading-5 bg-gray-100 dark:bg-gray-900 animate-pulse rounded-md p-3"
+        />
+        <div
+            class="text-md font-semibold leading-5 bg-gray-100 dark:bg-gray-900 animate-pulse rounded-md p-3"
+        />
+    </div>
+
+    <div class="w-full flex gap-2">
+        <div
+            class="bg-gray-100 dark:bg-gray-900 animate-pulse rounded-md p-2 w-2/3"
+        />
+        <div
+            class="bg-gray-100 dark:bg-gray-900 animate-pulse rounded-md p-2 w-1/3"
+        />
+    </div>
+</li>

--- a/src/components/SideMenu.svelte
+++ b/src/components/SideMenu.svelte
@@ -1,22 +1,23 @@
 <script lang="ts">
-    import { type Article } from '../types/article'
     import {
         setCategory,
         clearCategories,
         category,
     } from '../stores/filters.store'
+    import { articles } from '../stores/articles.store'
 
-    export let articles: Article[]
     let availableCategories: string[] = []
 
     $: {
-        availableCategories = Array.from(
-            new Set(
-                articles.flatMap((article) =>
-                    article.categories.map((category) => category.name),
+        if ($articles.length > 0) {
+            availableCategories = Array.from(
+                new Set(
+                    $articles.flatMap((article) =>
+                        article.categories.map((category) => category.name),
+                    ),
                 ),
-            ),
-        )
+            )
+        }
     }
 </script>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,18 +1,7 @@
 ---
 import Layout from '../layouts/Layout.astro'
-import { type Article } from '../types/article'
 import SideMenu from '../components/SideMenu.svelte'
 import ArticleList from '../components/ArticleList.svelte'
-import { cachedFetch } from '../utils/cached-fetch'
-
-let articles: Article[] = []
-
-try {
-    const response = await cachedFetch('https://cms.2077.xyz/api/articles')
-    articles = await response.clone().json()
-} catch (error) {
-    console.error(error)
-}
 ---
 
 <Layout
@@ -32,9 +21,11 @@ try {
                     these systems.
                 </p>
             </div>
-            <div class="flex-col lg:flex-row flex justify-between">
-                <SideMenu client:load articles={articles} />
-                <ArticleList client:load articles={articles} />
+            <div class="flex-col lg:flex-row flex w-full">
+                <SideMenu client:load />
+                <div class="w-full">
+                    <ArticleList client:load />
+                </div>
             </div>
         </section>
     </main>

--- a/src/stores/articles.store.ts
+++ b/src/stores/articles.store.ts
@@ -1,0 +1,8 @@
+import { atom } from 'nanostores'
+import type { Article } from '../types/article'
+
+export const articles = atom<Article[]>([])
+
+export function setArticles(a: Article[]) {
+    articles.set(a)
+}


### PR DESCRIPTION
This allows for faster first paint and give users less loading times when navigating between articles and the list.

Articles are stored in the UI using `nanostores` which are shared between `SideMenu` and `ArticleList`